### PR TITLE
Only use rule regex/path if rule.Description is empty

### DIFF
--- a/report/sarif.go
+++ b/report/sarif.go
@@ -59,11 +59,11 @@ func getRules(cfg config.Config) []Rules {
 		shortDescription := ShortDescription{
 			Text: rule.Description,
 		}
-		if rule.Regex != nil {
+		if rule.Description == "" && rule.Regex != nil {
 			shortDescription = ShortDescription{
 				Text: rule.Regex.String(),
 			}
-		} else if rule.Path != nil {
+		} else if rule.Description == "" && rule.Path != nil {
 			shortDescription = ShortDescription{
 				Text: rule.Path.String(),
 			}


### PR DESCRIPTION
sarif description output should prioritize rule.Description.

### Description:
The current sarif output creates a description based on the rule's regex instead of the rule's description, which makes very little sense when interpreted by tools that process sarif, such as GitHub Code Scanning. See image for illustration.

![image](https://github.com/newbishme/gitleaks/assets/5872086/359eb754-1535-44d0-b263-7dfbafa41dd9)

This change will improve upon that by using the rule's description, and use regex or path as the fallback instead.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
