### PR TITLE
Tighten aws-access-token detection

### DIFF
--- a/config/gitleaks.toml
+++ b/config/gitleaks.toml
@@ -132,9 +132,9 @@ keywords = [
 [[rules]]
 id = "aws-access-token"
 description = "AWS"
-regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+regex = '''(A3T[A-Z0-9]|AKIA|ASIA)[A-Z0-9]{16}'''
 keywords = [
-    "akia","agpa","aida","aroa","aipa","anpa","anva","asia",
+    "akia","asia",
 ]
 
 [[rules]]


### PR DESCRIPTION
Restrict aws-access-token global rule to only match on AKIA and ASIA

### Description:
See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html# for a list of identifiers. Only AKIA and ASIA seem to be real secrets. The rest might be User Group, Role, etc.

### Checklist:

* [ ] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
