### PR TITLE
Fix endColumn bug

### DIFF
--- a/detect/detect.go
+++ b/detect/detect.go
@@ -254,7 +254,7 @@ func (d *Detector) detectRule(fragment Fragment, rule config.Rule) []report.Find
 		}
 	}
 
-	matchIndices := rule.Regex.FindAllStringIndex(fragment.Raw, -1)
+	matchIndices := rule.Regex.FindAllStringIndex(strings.Trim(fragment.Raw, "\n"), -1)
 	for _, matchIndex := range matchIndices {
 		// extract secret from match
 		secret := strings.Trim(fragment.Raw[matchIndex[0]:matchIndex[1]], "\n")


### PR DESCRIPTION


### Description:
endColumn = 0 for an edge case is detected for the case of a secret contained in a yml file, without single quote, and have a new line immediately after.

### Checklist:

* [x] Does your PR pass tests?
* [ ] Have you written new tests for your changes?
* [ ] Have you lint your code locally prior to submission?
